### PR TITLE
Add screenshot function

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": 3,
   "name": "SnapFolio",
   "version": "1.0",
+  "permissions": ["activeTab"],
   "action": {
     "default_popup": "popup.html"
   }

--- a/popup.html
+++ b/popup.html
@@ -6,5 +6,6 @@
 </head>
 <body>
   <button id="show">Show SnapFolio</button>
+  <button id="screenshot">Take Screenshot</button>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -3,4 +3,14 @@ document.addEventListener('DOMContentLoaded', () => {
     alert('SnapFolio');
     console.log('SnapFolio');
   });
+
+  document.getElementById('screenshot').addEventListener('click', () => {
+    chrome.tabs.captureVisibleTab(null, {format: 'png'}, (dataUrl) => {
+      if (chrome.runtime.lastError) {
+        console.error(chrome.runtime.lastError);
+        return;
+      }
+      chrome.tabs.create({url: dataUrl});
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add a button to take screenshots and display them in a new tab
- capture visible tab on button click
- request the `activeTab` permission in manifest

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68526ba46d9c832387fabba3486ead2a