### PR TITLE
Add screenshot display page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SnapFolio",
   "version": "1.0",
-  "permissions": ["activeTab"],
+  "permissions": ["activeTab", "storage"],
   "action": {
     "default_popup": "popup.html"
   }

--- a/popup.js
+++ b/popup.js
@@ -10,7 +10,9 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error(chrome.runtime.lastError);
         return;
       }
-      chrome.tabs.create({url: dataUrl});
+      chrome.storage.local.set({screenshot: dataUrl}, () => {
+        chrome.tabs.create({url: chrome.runtime.getURL('screenshot.html')});
+      });
     });
   });
 });

--- a/screenshot.html
+++ b/screenshot.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Screenshot</title>
+  <script src="screenshot.js"></script>
+</head>
+<body>
+  <img id="screenshot" alt="Screenshot" />
+</body>
+</html>

--- a/screenshot.js
+++ b/screenshot.js
@@ -1,0 +1,9 @@
+// Display screenshot stored in chrome.storage
+
+document.addEventListener('DOMContentLoaded', () => {
+  chrome.storage.local.get('screenshot', (result) => {
+    if (result.screenshot) {
+      document.getElementById('screenshot').src = result.screenshot;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- capture screenshot and store it
- open new page to display screenshot
- allow extension to use chrome storage

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68526cbc1478832399a0aa4657326561