### PR TITLE
Fix screenshot concatenation order

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
       await new Promise(r => setTimeout(r, 200));
 
       const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, {format: 'png'});
-      images.push(dataUrl);
+      images.push({y: i * info.innerHeight, dataUrl});
     }
     await chrome.scripting.executeScript({
       target: {tabId: tab.id},
@@ -38,15 +38,17 @@ document.addEventListener('DOMContentLoaded', () => {
       args: [info.scrollY]
     });
 
+    images.sort((a, b) => a.y - b.y);
+
     const canvas = document.createElement('canvas');
-    const sample = await loadImage(images[0]);
+    const sample = await loadImage(images[0].dataUrl);
     canvas.width = sample.width;
     canvas.height = info.scrollHeight * info.devicePixelRatio;
     const ctx = canvas.getContext('2d');
 
-    for (let i = 0; i < images.length; i++) {
-      const img = await loadImage(images[i]);
-      ctx.drawImage(img, 0, i * info.innerHeight * info.devicePixelRatio);
+    for (const {y, dataUrl} of images) {
+      const img = await loadImage(dataUrl);
+      ctx.drawImage(img, 0, y * info.devicePixelRatio);
     }
 
     const finalUrl = canvas.toDataURL();


### PR DESCRIPTION
## Summary
- ensure screenshots are stored with their scroll position
- sort captured images by their vertical order before drawing

## Testing
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_68527165e4588323b8c954f3eee63d9f