### PR TITLE
Wait for scrollbars to fade before screenshot

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -49,7 +49,8 @@ document.addEventListener('DOMContentLoaded', () => {
         args: [i, sections]
       });
 
-      await new Promise(r => setTimeout(r, 200));
+      // Wait for scrollbars to fade out before capturing the screenshot
+      await new Promise(r => setTimeout(r, 500));
 
       const dataUrl = await chrome.tabs.captureVisibleTab(tab.windowId, {format: 'png'});
       images.push({y: i * info.innerHeight, dataUrl});


### PR DESCRIPTION
## Summary
- delay screenshot capture so overlay scrollbars disappear first

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853d7c29ccc8323a82ea9dc834f4b1b