### PR TITLE
Fix screenshot storage quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # SnapFolio
 
 Chrome extension to capture full-page screenshots and display them in a new tab.
+Captured screenshots are stored using `chrome.storage.session`, so they are only
+available for the current browser session and do not persist across restarts.

--- a/popup.js
+++ b/popup.js
@@ -88,7 +88,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const finalUrl = canvas.toDataURL();
 
-    await chrome.storage.local.set({screenshot: finalUrl});
+    try {
+      await chrome.storage.session.set({screenshot: finalUrl});
+    } catch (e) {
+      console.error('Failed to store screenshot:', e);
+    }
     chrome.tabs.create({url: chrome.runtime.getURL('screenshot.html')});
   });
 

--- a/screenshot.js
+++ b/screenshot.js
@@ -1,7 +1,7 @@
 // Display screenshot stored in chrome.storage
 
 document.addEventListener('DOMContentLoaded', () => {
-  chrome.storage.local.get('screenshot', (result) => {
+  chrome.storage.session.get('screenshot', (result) => {
     if (result.screenshot) {
       document.getElementById('screenshot').src = result.screenshot;
     }


### PR DESCRIPTION
## Summary
- use `chrome.storage.session` to store screenshots so we don't exceed the quota
- document use of session storage

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853db37d95c8323b548c819765b967f