### PR TITLE
Fix screenshot storage approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # SnapFolio
 
 Chrome extension to capture full-page screenshots and display them in a new tab.
-Captured screenshots are stored using `chrome.storage.session`, so they are only
-available for the current browser session and do not persist across restarts.
+Captured screenshots are passed to the viewer page using an in-memory object
+URL, so they are only available for the current browser session and do not
+persist across restarts.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SnapFolio",
   "version": "1.0",
-  "permissions": ["activeTab", "storage", "scripting"],
+  "permissions": ["activeTab", "scripting"],
   "action": {
     "default_popup": "popup.html"
   }

--- a/popup.js
+++ b/popup.js
@@ -89,11 +89,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const finalUrl = canvas.toDataURL();
 
     try {
-      await chrome.storage.session.set({screenshot: finalUrl});
+      const blob = await (await fetch(finalUrl)).blob();
+      const url = URL.createObjectURL(blob);
+      chrome.tabs.create({
+        url: chrome.runtime.getURL('screenshot.html?src=' + encodeURIComponent(url))
+      });
     } catch (e) {
-      console.error('Failed to store screenshot:', e);
+      console.error('Failed to create screenshot URL:', e);
     }
-    chrome.tabs.create({url: chrome.runtime.getURL('screenshot.html')});
   });
 
   function loadImage(src) {

--- a/screenshot.js
+++ b/screenshot.js
@@ -1,9 +1,9 @@
-// Display screenshot stored in chrome.storage
+// Display screenshot passed via query parameter
 
 document.addEventListener('DOMContentLoaded', () => {
-  chrome.storage.session.get('screenshot', (result) => {
-    if (result.screenshot) {
-      document.getElementById('screenshot').src = result.screenshot;
-    }
-  });
+  const params = new URLSearchParams(location.search);
+  const src = params.get('src');
+  if (src) {
+    document.getElementById('screenshot').src = src;
+  }
 });


### PR DESCRIPTION
## Summary
- avoid session storage quota by creating an in-memory object URL for the screenshot
- display screenshot based on URL query parameter
- remove unneeded storage permission
- update README to reflect new approach

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853dcfc156083238e88c7282fe06bc5