### PR TITLE
Handle missing screenshot parameter

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SnapFolio",
   "version": "1.0",
-  "permissions": ["activeTab", "scripting"],
+  "permissions": ["activeTab", "scripting", "storage"],
   "action": {
     "default_popup": "popup.html"
   }

--- a/popup.js
+++ b/popup.js
@@ -91,8 +91,12 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const blob = await (await fetch(finalUrl)).blob();
       const url = URL.createObjectURL(blob);
-      chrome.tabs.create({
-        url: chrome.runtime.getURL('screenshot.html?src=' + encodeURIComponent(url))
+
+      // Store the screenshot in case the query parameter is missing later
+      chrome.storage.local.set({lastScreenshot: finalUrl}, () => {
+        chrome.tabs.create({
+          url: chrome.runtime.getURL('screenshot.html?src=' + encodeURIComponent(url))
+        });
       });
     } catch (e) {
       console.error('Failed to create screenshot URL:', e);

--- a/screenshot.js
+++ b/screenshot.js
@@ -3,7 +3,16 @@
 document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(location.search);
   const src = params.get('src');
+  const img = document.getElementById('screenshot');
   if (src) {
-    document.getElementById('screenshot').src = src;
+    img.src = src;
+  } else {
+    chrome.storage.local.get('lastScreenshot', data => {
+      if (data.lastScreenshot) {
+        img.src = data.lastScreenshot;
+      } else {
+        img.alt = 'Screenshot not available';
+      }
+    });
   }
 });


### PR DESCRIPTION
## Summary
- store the last captured screenshot in `chrome.storage`
- read stored screenshot from `screenshot.js` if the `src` parameter is missing
- add the `storage` permission to `manifest.json`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853df2050c48323a3c8e2ddc4ee27ae