### PR TITLE
Fix quota error by removing storage usage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SnapFolio",
   "version": "1.0",
-  "permissions": ["activeTab", "scripting", "storage"],
+  "permissions": ["activeTab", "scripting"],
   "action": {
     "default_popup": "popup.html"
   }

--- a/popup.js
+++ b/popup.js
@@ -92,11 +92,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const blob = await (await fetch(finalUrl)).blob();
       const url = URL.createObjectURL(blob);
 
-      // Store the screenshot in case the query parameter is missing later
-      chrome.storage.local.set({lastScreenshot: finalUrl}, () => {
-        chrome.tabs.create({
-          url: chrome.runtime.getURL('screenshot.html?src=' + encodeURIComponent(url))
-        });
+      chrome.tabs.create({
+        url: chrome.runtime.getURL('screenshot.html?src=' + encodeURIComponent(url))
       });
     } catch (e) {
       console.error('Failed to create screenshot URL:', e);

--- a/screenshot.js
+++ b/screenshot.js
@@ -7,12 +7,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (src) {
     img.src = src;
   } else {
-    chrome.storage.local.get('lastScreenshot', data => {
-      if (data.lastScreenshot) {
-        img.src = data.lastScreenshot;
-      } else {
-        img.alt = 'Screenshot not available';
-      }
-    });
+    img.alt = 'Screenshot not available';
   }
 });


### PR DESCRIPTION
## Summary
- avoid storing screenshot data in `chrome.storage` to fix the `Resource::kQuotaBytes` error
- remove storage permission

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853e21854948323883fb88c4de03c98